### PR TITLE
Fixed loading of paired models. Processor class is now a singular utils function. Across chain features added for paired class.

### DIFF
--- a/sonnia/sonia.py
+++ b/sonnia/sonia.py
@@ -257,8 +257,9 @@ class Sonia(object):
             Indices of features seq projects onto.
 
         """
+        seq_features = set()
+
         if features is None:
-            seq_features = set()
 
             cdr3_len = len(seq[0])
             cdr3_len_key = (f'l{cdr3_len}',)
@@ -277,15 +278,15 @@ class Sonia(object):
 
             if self.gene_features == 'none':
                 pass
-            elif self.gene_features == 'indep_vj':
-                v_key = (gene_to_num_str(seq[1], 'V'),)
-                seq_features.add(self.feature_dict[v_key])
-                j_key = (gene_to_num_str(seq[2], 'J'),)
-                seq_features.add(self.feature_dict[j_key])
             elif self.gene_features == 'v':
                 v_key = (gene_to_num_str(seq[1], 'V'),)
                 seq_features.add(self.feature_dict[v_key])
             elif self.gene_features == 'j':
+                j_key = (gene_to_num_str(seq[2], 'J'),)
+                seq_features.add(self.feature_dict[j_key])
+            elif self.gene_features == 'indep_vj':
+                v_key = (gene_to_num_str(seq[1], 'V'),)
+                seq_features.add(self.feature_dict[v_key])
                 j_key = (gene_to_num_str(seq[2], 'J'),)
                 seq_features.add(self.feature_dict[j_key])
             elif self.gene_features == 'joint_vj':
@@ -301,7 +302,6 @@ class Sonia(object):
         else:
             feature_dict = {tuple(feature): idx
                             for idx, feature in enumerate(features)}
-            seq_features = set()
 
             cdr3_len = len(seq[0])
             cdr3_len_key = (f'l{cdr3_len}',)

--- a/sonnia/sonnia_paired.py
+++ b/sonnia/sonnia_paired.py
@@ -7,7 +7,7 @@ from copy import copy
 import logging
 import multiprocessing as mp
 import os
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 logging.getLogger('tensorflow').disabled = True
 
@@ -31,6 +31,7 @@ class SoNNiaPaired(SoniaPaired):
     def __init__(self,
                  *args: Tuple[Any],
                  gene_features: str = 'indep_vj',
+                 across_chain_features: Optional[Iterable[str]] = None,
                  independent_chains: bool = False,
                  min_energy_clip: int = -10,
                  max_energy_clip: int = 10,
@@ -39,16 +40,21 @@ class SoNNiaPaired(SoniaPaired):
                  **kwargs: Dict[str, Any]
                 ) -> None:
         invalid_gene_features = {'vjl', 'none'}
-        if gene_features in invalid_gene_features:
-            valid_gene_features = f'{GENE_FEATURE_OPTIONS - invalid_gene_features}'[1:-1]
-            invalid_gene_features = f'{invalid_gene_features}'[1:-1]
-            raise ValueError(f'gene_features = \'{gene_features}\' is an invalid option '
-                             'when using a deep SoNNiaPaired model. Use one of the '
-                             f'following instead: {valid_gene_features}.')
+        if deep:
+            if gene_features in invalid_gene_features:
+                valid_gene_features = f'{GENE_FEATURE_OPTIONS - invalid_gene_features}'[1:-1]
+                invalid_gene_features = f'{invalid_gene_features}'[1:-1]
+                raise ValueError(f'gene_features = \'{gene_features}\' is an invalid option '
+                                 'when using a deep SoNNiaPaired model. Use one of the '
+                                 f'following instead: {valid_gene_features}.')
+            if across_chain_features is not None:
+                raise RuntimeError('across_chain_features must be None '
+                                   'when using a deep SonniaPaired model.')
 
         self.deep = deep
         self.independent_chains = independent_chains
         SoniaPaired.__init__(self, *args, gene_features=gene_features,
+                             across_chain_features=across_chain_features,
                              min_energy_clip=min_energy_clip,
                              max_energy_clip=max_energy_clip,
                              l2_reg=l2_reg, **kwargs)

--- a/sonnia/utils.py
+++ b/sonnia/utils.py
@@ -169,7 +169,7 @@ def define_pgen_model(pgen_model: Optional[str] = None,
 
     return out_tup
 
-def filter_seqs(seqs: Union[Iterable[Iterable[str]], str],
+def filter_seqs(seqs: Union[Iterable[Iterable[str]], pd.DataFrame, str],
                 model_dir: str,
                 seq_col: str = 'amino_acid',
                 v_col: str = 'v_gene',
@@ -236,11 +236,15 @@ def filter_seqs(seqs: Union[Iterable[Iterable[str]], str],
                     functional_genes.add(gene.partition('*')[0])
         return functional_genes
 
+    model_dir = get_model_dir(model_dir)
+
     v_genes = get_functional_genes(os.path.join(model_dir, 'V_gene_CDR3_anchors.csv'))
     j_genes = get_functional_genes(os.path.join(model_dir, 'J_gene_CDR3_anchors.csv'))
 
     if isinstance(seqs, str):
         df = pd.read_csv(seqs, **kwargs)
+    elif isinstance(seqs, pd.DataFrame):
+        df = seqs
     else:
         df = pd.DataFrame(seqs)
         seq_col = 0 if not isinstance(seq_col, int) else seq_col


### PR DESCRIPTION
## Bugs fixed
- Only a ppost_model or both pgen models must be specified for paired models.
- Q factors saved to sequence files are properly normalized

## New features
- If loading a ppost_model, there must necessarily be a features.tsv and log.txt file. If a SoNNia model is being loaded, a model.h5 file must be present. If these files are not present, the program exits.
- `find_seq_features` has been optimized better for when features are left out
- Linear paired models now have `across_chain_features` which allows the model to learn selection on paired gene usages. Options are subset of `['vhvl', 'jhjl', 'vhjl', 'jhvl']`.
- `utils.get_model_dir` obtains the default models easily
- All chain prefixes are checked in the anchors files.
- `sonnia.utils.filter_seqs` accomplishes what the `Processing` class did. Because it's in the `utils` script, it is also quick to load since there are no dependencies on TensorFlow in `utils`. Moreover, `filter_seqs` is quicker than the `Processing` class and handles iterables of strings, strings pointing to csv files, and pandas DataFrames. Additionally, `utils.filter_seqs` can take in default models as parameters for `model_dir`. E.g., `utils.filter_seqs(filepath_to_seqs, 'humanTRB')`. The idea here is that whenever data_seqs or gen_seqs are loaded to a model, `utils.filter_seqs` can be called to filter bad sequences, and it will do so quickly, eliminating the user's need to do so.