### PR TITLE
Mitigate RAM issues with dense one-hot encoding, fixed plotting functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,21 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sonnia"
-version = "0.2.4"
+version = "0.3.0"
 #dynamic = ["version"]
-dependencies = ['numpy','tensorflow>=2.1.0','matplotlib','olga>=1.1.3','tqdm']
+requires-python = ">=3.9"
+dependencies = [
+    'keras >= 3',
+    'matplotlib',
+    'olga >= 1.1.3',
+    'numpy',
+    'pandas',
+    'seaborn',
+    'scikit-learn',
+    'scipy >= 1.10',
+    'tensorflow >= 2.16',
+    'tqdm',
+]
 authors = [ {name = "Giulio Isacchini", email = "giulioisac@gmail.com"}]
 maintainers = [{name = "Giulio Isacchini", email = "giulioisac@gmail.com"}]
 description = 'SoNNia is a Python 3 software developed to infer selection pressures on features of amino acid CDR3 sequences. SoNNia takes as input TCR CDR3 amino acid sequences with  V and J genes. Its output is sequence-level selection factors which indicate how more or less represented this sequence would be in the selected pool as compared to the pre-selected pool. These in turn could be used to calculate the probability of observing any sequence after selection and sample from the selected repertoire.'
@@ -25,11 +37,15 @@ classifiers=[
             'Topic :: Scientific/Engineering :: Medical Science Apps.',
             'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
             'Natural Language :: English',
-            'Programming Language :: Python :: 3.6']
+            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
+            ]
              
 [project.urls]
 Homepage = "https://github.com/statbiophys/soNNia"
-Documentation = "https://github.com/statbiophys/soNNia"
+Documentation = "https://sonnia.readthedocs.io/en/latest/index.html"
 
 [project.scripts]
 sonnia-infer='sonnia.infer:main'

--- a/sonnia/classifiers.py
+++ b/sonnia/classifiers.py
@@ -1,7 +1,8 @@
-import numpy as np 
-from sonia.sonia_leftpos_rightpos import SoniaLeftposRightpos
+import keras
+import numpy as np
 from tqdm import tqdm
-import tensorflow.keras as keras
+
+from sonia.sonia_leftpos_rightpos import SoniaLeftposRightpos
 
 class Linear(object):
     '''

--- a/sonnia/evaluate.py
+++ b/sonnia/evaluate.py
@@ -36,20 +36,13 @@ import time
 from tqdm import tqdm
 import multiprocessing as mp
 
-#Set input = raw_input for python 2
-try:
-    import __builtin__
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
-
 def chunks(lst, n):
     return [lst[i:i + n] for i in range(0, len(lst), n)]
 
 def main():
     """ Evaluate sequences."""
     parser = OptionParser(conflict_handler="resolve")
-    
+
     #specify model
     parser.add_option('--humanTRA', '--human_T_alpha', action='store_true', dest='humanTRA', default=False, help='use default human TRA model (T cell alpha chain)')
     parser.add_option('--humanTRB', '--human_T_beta', action='store_true', dest='humanTRB', default=False, help='use default human TRB model (T cell beta chain)')
@@ -81,7 +74,7 @@ def main():
     parser.add_option('-m', '--max_number_of_seqs', type='int',metavar='N', dest='max_number_of_seqs', help='evaluate for at most N sequences.')
     parser.add_option('--lines_to_skip', type='int',metavar='N', dest='lines_to_skip', default = 0, help='skip the first N lines of the file. Default is 0.')
 
-    
+
     #delimeters
     parser.add_option('-d', '--delimiter', type='choice', dest='delimiter',  choices=['tab', 'space', ',', ';', ':'], help="declare infile delimiter. Default is tab for .tsv input files, comma for .csv files, and any whitespace for all others. Choices: 'tab', 'space', ',', ';', ':'")
     parser.add_option('--raw_delimiter', type='str', dest='delimiter', help="declare infile delimiter as a raw string.")

--- a/sonnia/generate.py
+++ b/sonnia/generate.py
@@ -19,7 +19,6 @@
 
 This program generates sequences
 """
-
 from __future__ import print_function, division,absolute_import
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -30,13 +29,6 @@ from sonnia.sonia import Sonia
 import sonnia.sonnia
 import numpy as np
 from tqdm import tqdm
-
-#Set input = raw_input for python 2
-try:
-    import __builtin__
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
 
 def chuncks(n,size):
     if n%size: return int(n/size)*[size]+[n%size]

--- a/sonnia/infer.py
+++ b/sonnia/infer.py
@@ -19,7 +19,6 @@
 
 This program will infer a seleciton model
 """
-
 from __future__ import print_function, division,absolute_import
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -35,18 +34,10 @@ import numpy as np
 from tqdm import tqdm
 import sonnia.sonnia
 
-
-#Set input = raw_input for python 2
-try:
-    import __builtin__
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
-
 def main():
     """ Evaluate sequences."""
     parser = OptionParser(conflict_handler="resolve")
-    
+
     #specify model
     parser.add_option('--humanTRA', '--human_T_alpha', action='store_true', dest='humanTRA', default=False, help='use default human TRA model (T cell alpha chain)')
     parser.add_option('--humanTRB', '--human_T_beta', action='store_true', dest='humanTRB', default=False, help='use default human TRB model (T cell beta chain)')

--- a/sonnia/plotting.py
+++ b/sonnia/plotting.py
@@ -15,11 +15,19 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>."""
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+import os
+from typing import Optional, Type
 
-import numpy as np
-import os  
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from sonnia.sonia import Sonia
+from sonnia.sonnia import SoNNia
+from sonnia.sonia_paired import SoniaPaired
+from sonnia.sonnia_paired import SoNNiaPaired
 
 class Plotter(object):
     """Class used to plot stuff
@@ -32,7 +40,6 @@ class Plotter(object):
 
     Methods
     ----------
-    
     plot_model_learning(save_name = None)
         Plots L1 convergence curve and marginal scatter.
 
@@ -42,28 +49,30 @@ class Plotter(object):
     plot_ppost(ppost_data=[],ppost_gen=[],pppst_model=[],n_bins=100)
         Histogram plot of ppost. You need to evalute them first.
 
-    plot_model_parameters(low_freq_mask = 0.0)
-        For LengthPos model only. Plot the model parameters using plot_onepoint_values
-
-    plot_marginals_length_corrected(min_L = 8, max_L = 16, log_scale = True)
-        For LengthPos model only. Plot length normalized marginals.
-    
     plot_vjl(save_name = None)
         Plots marginals of V gene, J gene and cdr3 length
-    
+
     plot_logQ(save_name=None)
         Plots logQ of data and generated sequences
 
     plot_ratioQ(self,save_name=None)
-        Plots the ratio of P(Q) in data and pre-selected pool. Useful for model validation. 
-
+        Plots the ratio of P(Q) in data and pre-selected pool. Useful for model validation.
     """
 
-    def __init__(self,sonia_model=None):
-        if type(sonia_model)==str or sonia_model is None: 
-            print('ERROR: you need to pass a Sonia object')
-            return
-        self.sonia_model=sonia_model
+    def __init__(
+        self,
+        sonia_model: Type[Sonia]
+    ):
+        correct_type = False
+        for sonia_type in (Sonia, SoNNia, SoniaPaired, SoNNiaPaired):
+            correct_type += isinstance(sonia_model, sonia_type)
+        if not correct_type:
+            raise RuntimeError(
+                'Plotter must be initialized with a Sonia, SoNNia, SoniaPaired '
+                'or SoNNiaPaired object.'
+            )
+
+        self.sonia_model = sonia_model
 
     def plot_prob(self, data=[],gen=[],model=[],n_bins=30,save_name=None,bin_min=-20,bin_max=-5,ptype='P_{pre}',figsize=(6,4)):
         '''Histogram plot of Pgen
@@ -92,44 +101,58 @@ class Plotter(object):
         if save_name is not None:
             fig.savefig(save_name)
         plt.show()
-        
-    def plot_model_learning(self, save_name = None):
 
-        """Plots L1 convergence curve and marginal scatter.
+    def plot_model_learning(
+        self,
+        save_name: Optional[str] = None
+    ) -> None:
+        """
+        Plot L1 convergence curve and marginal scatter.
 
         Parameters
         ----------
         save_name : str or None
             File name to save output figure. If None (default) does not save.
 
+        Returns
+        -------
+        None
         """
 
-        min_for_plot = 1/(10.*np.power(10, np.ceil(np.log10(len(self.sonia_model.data_seqs)))))
+        if len(self.sonia_model.data_seqs):
+            num_data_seqs = len(self.sonia_model.data_seqs)
+            min_for_plot = 10**(np.floor(np.log10(num_data_seqs)))
+        else:
+            min_nonzero_marginal = np.min(self.sonia_model.data_marginals[self.sonia_model.data_marginals != 0])
+            min_for_plot = 10**(np.floor(np.log10(min_nonzero_marginal)))
+
         fig = plt.figure(figsize =(9, 4))
-        
-        fig.add_subplot(121)
 
-        plt.loglog(self.sonia_model.data_marginals, self.sonia_model.gen_marginals, 'r.', alpha = 0.2, markersize=1)
-        plt.loglog(self.sonia_model.data_marginals, self.sonia_model.model_marginals, 'b.', alpha = 0.2, markersize=1)
-        plt.loglog([],[], 'r.', label = 'Raw marginals')
-        plt.loglog([],[], 'b.', label = 'Model adjusted marginals')
+        ax_marg = fig.add_subplot(121)
 
-        plt.loglog([min_for_plot, 2], [min_for_plot, 2], 'k--', linewidth = 0.5)
-        plt.xlim([min_for_plot, 1])
-        plt.ylim([min_for_plot, 1])
+        ax_marg.loglog(self.sonia_model.data_marginals, self.sonia_model.gen_marginals, 'r.', alpha=0.2, markersize=1)
+        ax_marg.loglog(self.sonia_model.data_marginals, self.sonia_model.model_marginals, 'b.', alpha=0.2, markersize=1)
+        ax_marg.loglog([],[], 'r.', label='Raw marginals')
+        ax_marg.loglog([],[], 'b.', label='Model adjusted marginals')
 
-        plt.xlabel('Marginals over data', fontsize = 13)
-        plt.ylabel('Marginals over generated sequences', fontsize = 13)
-        plt.legend(loc = 2, fontsize = 10)
-        plt.title('Marginal Scatter', fontsize = 15)
-        
-        fig.add_subplot(122)
-        plt.title('Likelihood', fontsize = 15)
-        plt.plot(self.sonia_model.likelihood_train,label='train',c='k')
-        plt.plot(self.sonia_model.likelihood_test,label='validation',c='r')
-        plt.legend(fontsize = 10)
-        plt.xlabel('Iteration', fontsize = 13)
-        plt.ylabel('Likelihood', fontsize = 13)
+        ax_marg.loglog([min_for_plot, 2], [min_for_plot, 2], 'k--', linewidth=0.5)
+        ax_marg.set_xlim([min_for_plot, 1])
+        ax_marg.set_ylim([min_for_plot, 1])
+
+        ax_marg.set_xlabel('Marginals over data', fontsize=13)
+        ax_marg.set_ylabel('Marginals over generated sequences', fontsize=13)
+        ax_marg.legend(loc=2, fontsize=10)
+        ax_marg.set_title('Marginal Scatter', fontsize=15)
+        ax_marg.tick_params(labelsize=12)
+
+        ax_llh = fig.add_subplot(122)
+        ax_llh.set_title('Likelihood', fontsize=15)
+        ax_llh.plot(self.sonia_model.likelihood_train, label='train', c='k')
+        ax_llh.plot(self.sonia_model.likelihood_test, label='validation', c='r')
+        ax_llh.legend(fontsize=10)
+        ax_llh.set_xlabel('Iteration', fontsize=13)
+        ax_llh.set_ylabel('Likelihood', fontsize=13)
+        ax_llh.tick_params(labelsize=12)
 
         fig.tight_layout()
 
@@ -137,336 +160,223 @@ class Plotter(object):
             fig.savefig(save_name)
         else: plt.show()
 
-    def plot_onepoint_values(self, onepoint = None ,onepoint_dict = None,  min_L = None, max_L = None, min_val = None, max_value = None, 
-                             title = '', cmap = 'seismic', bad_color = 'black', aa_color = 'white', marginals = False):
-        """ plot a function of aa, length and position from left, one heatplot per aa
-        
-        
-        Parameters
-        ----------
-        onepoint : ndarray
-            array containting one-point values to plot, in the same shape as self.features, 
-            expected unless onepoint_dict is given
-        onepoint_dict : dict
-            dict of the one-point values to plot, keyed by the feature tuples such as (l12,aA8)
-        min_L : int
-            Minimum length CDR3 sequence
-        max_L : int
-            Maximum length CDR3 sequence
-        min_val : float
-            minimum value to plot
-        max_val : float
-            maximum value to plot
-        title : string
-            title of plot to display
-        cmap : colormap 
-            colormap to use for the heatplots
-        bad_color : string
-            color to use for nan values - used primarly for cells where position is larger than length
-        aa_color : string
-            color to use for amino acid names for each heatplot displayed on the bad_color background
-        marginals : bool
-            if true, indicates marginals are to be plotted and this sets cmap, bad_color and aa_color
-        
+    def plot_vjl(
+        self,
+        save_name: Optional[str] = None
+    ) -> None:
         """
-        
-        from mpl_toolkits.axes_grid1 import AxesGrid
-        
-        if marginals: #style for plotting marginals
-            cmap = 'plasma'
-            bad_color = 'white'
-            aa_color = 'black'
-            
-        amino_acids_dict = {'A': 'Ala', 'R': 'Arg', 'N': 'Asn', 'D': 'Asp', 'C': 'Cys', 'E': 'Glu', 'Q': 'Gln', 'G': 'Gly', 'H': 'His', 'I': 'Ile',
-                       'L': 'Leu', 'K': 'Lys', 'M': 'Met', 'F': 'Phe', 'P': 'Pro', 'S': 'Ser', 'T': 'Thr', 'W': 'Trp', 'Y': 'Tyr', 'V': 'Val'}
-        
-        fig = plt.figure(figsize=(12, 8))
-    
-        grid = AxesGrid(fig, 111,
-                    nrows_ncols=(4, 5),
-                    axes_pad=0.05,
-                    cbar_mode='single',
-                    cbar_location='right',
-                    cbar_pad=0.1,
-                    share_all = True
-                    )
-        
-        current_cmap = matplotlib.cm.get_cmap(name = cmap)
-        current_cmap.set_bad(color = bad_color)
-        current_cmap.set_under(color = 'gray')
-        
-        for a,aa in enumerate(self.sonia_model.amino_acids):
-        
-            M = np.empty((max_L - min_L + 1, max_L))
-            M[:] = np.nan
-        
-            for l in range(min_L, max_L + 1):
-                for i in range(l):
-                    if onepoint_dict == None:
-                        M[l-min_L,i] = onepoint[self.sonia_model.feature_dict[('l' + str(l), 'a' + aa + str(i))]]
-                    else:
-                        M[l-min_L,i] = onepoint_dict.get(('l' + str(l), 'a' + aa + str(i)), np.nan)
-            
-            im = grid[a].imshow(M, cmap = current_cmap, vmin = min_val, vmax = max_value)
-            grid[a].text(0.75,0.7,amino_acids_dict[aa],transform=grid[a].transAxes, color = aa_color, fontsize = 'large', fontweight = 'bold')
-    
-        grid.cbar_axes[0].colorbar(im)
-        grid.axes_llc.set_xticks(range(0, max_L, 2))
-        grid.axes_llc.set_xticklabels(range(1, max_L + 1, 2))
-        grid.axes_llc.set_yticks(range(0, max_L - min_L + 1 ))
-        grid.axes_llc.set_yticklabels(range(min_L, max_L + 1))
-        
-        fig.suptitle(title, fontsize=20.00)
-
-    def plot_model_parameters(self, low_freq_mask = 0.0):
-        """ plot the model parameters using plot_onepoint_values
-        
-        Parameters
-        ----------
-        low_freq_mask : float
-            threshold on the marginals, anything lower would be grayed out
-        
-        """
-        p1 = np.exp(-self.sonia_model.model.get_weights()[0].flatten())
-        if low_freq_mask:
-            p1[(self.sonia_model.data_marginals < low_freq_mask) & (self.sonia_model.gen_marginals < low_freq_mask)] = -1
-        self.plot_onepoint_values(onepoint = p1, min_L = 8, max_L = 16, min_val = 0, max_value = 2, title = 'model parameters q=exp(-E)')
-        
-    def norm_marginals(self, marg, min_L = None, max_L = None):
-        """ renormalizing the marginals accourding to length, so the sum of the marginals over all amino acid 
-            for one position/length combination will be 1 (and not the fraction of CDR3s of this length)
-            
-        Parameters
-        ----------
-        marg : ndarray
-            the marginal to renormalize
-        min_L : int
-            Minimum length CDR3 sequence, if not given taken from class attribute
-        max_L : int
-            Maximum length CDR3 sequence, if not given taken from class attribute
-                   
-        
-        """
-        
-        if min_L == None:
-            min_L = self.min_L
-        if max_L == None:
-            max_L = self.max_L
-            
-        for l in range(min_L, max_L + 1):
-            for i in range(l):
-                for aa in self.sonia_model.amino_acids:
-                    if marg[self.sonia_model.feature_dict[('l' + str(l),)]]>0:
-                        marg[self.sonia_model.feature_dict[('l' + str(l), 'a' + aa + str(i))]] /= marg[self.sonia_model.feature_dict[('l' + str(l),)]]
-
-        return marg 
-        
-
-    def plot_marginals_length_corrected(self, min_L = 8, max_L = 16, log_scale = True):
-        
-        """ plot length normalized marginals using plot_onepoint_values
-        
-        Parameters
-        ----------
-        min_L : int
-            Minimum length CDR3 sequence, if not given taken from class attribute
-        max_L : int
-            Maximum length CDR3 sequence, if not given taken from class attribute
-        log_scale : bool
-            if True (default) plots marginals on a log scale
-        """
-        
-        if log_scale:
-            pc = 1e-10 #pseudo count to add to marginals to avoid log of zero
-            self.plot_onepoint_values(onepoint = np.log(self.norm_marginals(self.sonia_model.data_marginals) + pc), min_L=min_L, max_L=max_L ,
-                                      min_val = -8, max_value = 0, title = 'log(data marginals)', marginals = True)
-            self.plot_onepoint_values(onepoint = np.log(self.norm_marginals(self.sonia_model.gen_marginals) + pc), min_L=min_L, max_L=max_L, 
-                                      min_val = -8, max_value = 0, title = 'log(generated marginals)', marginals = True)
-            self.plot_onepoint_values(onepoint = np.log(self.norm_marginals(self.sonia_model.model_marginals) + pc), min_L=min_L, max_L=max_L, 
-                                      min_val = -8, max_value = 0, title = 'log(model marginals)', marginals = True)
-        else:
-            self.plot_onepoint_values(onepoint = self.norm_marginals(self.sonia_model.data_marginals), min_L=min_L, max_L=max_L, 
-                                      min_val = 0, max_value = 1, title = 'data marginals', marginals = True)       
-            self.plot_onepoint_values(onepoint = self.norm_marginals(self.sonia_model.gen_marginals), min_L=min_L, max_L=max_L, 
-                                      min_val = 0, max_value = 1, title = 'generated marginals', marginals = True)
-            self.plot_onepoint_values(onepoint = self.norm_marginals(self.sonia_model.model_marginals), min_L=min_L, max_L=max_L, 
-                                      min_val = -8, max_value = 0, title = 'model marginals', marginals = True)
-            
-            
-    def plot_vjl(self,save_name=None):
-        
-        """Plots marginals of V gene, J gene and cdr3 length
+        Plot marginals of V gene, J gene and cdr3 length
 
         Parameters
         ----------
-        save_name : str or None
+        save_name : str, optional
             File name to save output figure. If None (default) does not save.
 
-        """        
-        initial=np.array([s[0][0] for s in self.sonia_model.features])
-        l_length=len(np.arange(len(initial))[initial=='l'])
+        Returns
+        -------
+        None
+        """
+        df = pd.DataFrame(
+            {'feature': self.sonia_model.features,
+             'model_marginal': self.sonia_model.model_marginals,
+             'gen_marginal': self.sonia_model.gen_marginals,
+             'data_marginal': self.sonia_model.data_marginals,
+            }
+        ).explode(
+            'feature'
+        ).groupby(
+            ['feature']
+        )[['model_marginal', 'gen_marginal', 'data_marginal']].sum()
 
-        if self.sonia_model.gene_features=='joint_vj': 
-            if 'Paired' in type(self.sonia_model).__name__:
-                initial=np.array([s[0][:3] for s in self.sonia_model.features])
-                vj_features=np.array(self.sonia_model.features)[initial=='v_l']
-                j_genes_l=np.unique([feat[1]  for feat in vj_features if 'j' in feat[1]])
-                v_genes_l=np.unique([feat[0] for feat in vj_features if 'v' in feat[0] ])
-                vj_features=np.array(self.sonia_model.features)[initial=='v_h']
-                j_genes_h=np.unique([feat[1]  for feat in vj_features if 'j' in feat[1]])
-                v_genes_h=np.unique([feat[0] for feat in vj_features if 'v' in feat[0] ])
-                
-                j_genes,v_genes=np.concatenate((j_genes_h,j_genes_l)),np.concatenate((v_genes_h,v_genes_l))
-                
-                v_model_marginals=np.concatenate((np.array(self.sonia_model.model_marginals)[initial=='v_h'].reshape(len(v_genes_h),len(j_genes_h)).sum(axis=1),
-                                                  np.array(self.sonia_model.model_marginals)[initial=='v_l'].reshape(len(v_genes_l),len(j_genes_l)).sum(axis=1)))
-                v_data_marginals=np.concatenate((np.array(self.sonia_model.data_marginals)[initial=='v_h'].reshape(len(v_genes_h),len(j_genes_h)).sum(axis=1),
-                                                  np.array(self.sonia_model.data_marginals)[initial=='v_l'].reshape(len(v_genes_l),len(j_genes_l)).sum(axis=1)))
-                v_gen_marginals=np.concatenate((np.array(self.sonia_model.gen_marginals)[initial=='v_h'].reshape(len(v_genes_h),len(j_genes_h)).sum(axis=1),
-                                                  np.array(self.sonia_model.gen_marginals)[initial=='v_l'].reshape(len(v_genes_l),len(j_genes_l)).sum(axis=1)))
-                
-                j_model_marginals=np.concatenate((np.array(self.sonia_model.model_marginals)[initial=='v_h'].reshape(len(v_genes_h),len(j_genes_h)).sum(axis=0),
-                                                  np.array(self.sonia_model.model_marginals)[initial=='v_l'].reshape(len(v_genes_l),len(j_genes_l)).sum(axis=0)))
-                j_data_marginals=np.concatenate((np.array(self.sonia_model.data_marginals)[initial=='v_h'].reshape(len(v_genes_h),len(j_genes_h)).sum(axis=0),
-                                                  np.array(self.sonia_model.data_marginals)[initial=='v_l'].reshape(len(v_genes_l),len(j_genes_l)).sum(axis=0)))
-                j_gen_marginals=np.concatenate((np.array(self.sonia_model.gen_marginals)[initial=='v_h'].reshape(len(v_genes_h),len(j_genes_h)).sum(axis=0),
-                                                  np.array(self.sonia_model.gen_marginals)[initial=='v_l'].reshape(len(v_genes_l),len(j_genes_l)).sum(axis=0)))
-                
-            else:    
-                vj_features=np.array(self.sonia_model.features)[initial=='v']
-                j_genes=np.unique([feat[1]  for feat in vj_features if 'j' in feat[1]])
-                v_genes=np.unique([feat[0] for feat in vj_features if 'v' in feat[0] ])
-                v_model_marginals=np.array(self.sonia_model.model_marginals)[initial=='v'].reshape(len(v_genes),len(j_genes)).sum(axis=1)
-                v_data_marginals=np.array(self.sonia_model.data_marginals)[initial=='v'].reshape(len(v_genes),len(j_genes)).sum(axis=1)
-                v_gen_marginals=np.array(self.sonia_model.gen_marginals)[initial=='v'].reshape(len(v_genes),len(j_genes)).sum(axis=1)
-                j_model_marginals=np.array(self.sonia_model.model_marginals)[initial=='v'].reshape(len(v_genes),len(j_genes)).sum(axis=0)
-                j_data_marginals=np.array(self.sonia_model.data_marginals)[initial=='v'].reshape(len(v_genes),len(j_genes)).sum(axis=0)
-                j_gen_marginals=np.array(self.sonia_model.gen_marginals)[initial=='v'].reshape(len(v_genes),len(j_genes)).sum(axis=0)
+        labels = ('POST marginals', 'DATA marginals', 'GEN marginals')
+        marg_types = ('model', 'data', 'gen')
+
+        fig = plt.figure(figsize=(16,4))
+        ax_cdr3 = fig.add_subplot(121)
+        if df.index.str.contains('_h').any():
+            for chain_type in ('h', 'l'):
+                df_l = df[df.index.str[:3] == f'l_{chain_type}'].assign(
+                    position=lambda x: x.index.str[3:].astype(int)
+                ).sort_values(
+                    'position'
+                )
+                for idx, (label, marg_type) in enumerate(zip(labels, marg_types)):
+                    if chain_type == 'h':
+                        ax_cdr3.plot(
+                            df_l['position'].values,
+                            df_l[f'{marg_type}_marginal'].values,
+                            label=f'heavy {label}', alpha=0.9
+                        )
+                    else:
+                        ax_cdr3.plot(
+                            df_l['position'].values,
+                            df_l[f'{marg_type}_marginal'].values,
+                            label=f'light {label}', alpha=0.9, color=f'C{idx + 3}'
+                        )
         else:
-            v_genes=np.array([g[0] for g in np.array(self.sonia_model.features)[initial=='v']])
-            j_genes=np.array([g[0] for g in np.array(self.sonia_model.features)[initial=='j']])
-            v_model_marginals=np.array(self.sonia_model.model_marginals)[initial=='v']
-            v_data_marginals=np.array(self.sonia_model.data_marginals)[initial=='v']
-            v_gen_marginals=np.array(self.sonia_model.gen_marginals)[initial=='v']
-            j_model_marginals=np.array(self.sonia_model.model_marginals)[initial=='j']
-            j_data_marginals=np.array(self.sonia_model.data_marginals)[initial=='j']
-            j_gen_marginals=np.array(self.sonia_model.gen_marginals)[initial=='j']
+            df_l = df[df.index.str[0] == 'l'].assign(
+                position=lambda x: x.index.str[1:].astype(int)
+            ).sort_values(
+                'position'
+            )
+            for label, marg_type in zip(labels, marg_types):
+                ax_cdr3.plot(
+                    df_l['position'].values,
+                    df_l[f'{marg_type}_marginal'].values,
+                    label=label, alpha=0.9
+                )
 
+        ax_cdr3.tick_params(rotation=90, axis='x')
+        ax_cdr3.grid()
+        ax_cdr3.legend(framealpha=1, fontsize=12)
+        ax_cdr3.set_title('CDR3 LENGTH DISTRIBUTION',fontsize=20)
 
-
-            
-        fig=plt.figure(figsize=(16,4))
-        plt.subplot(121)
-        if 'Paired' in type(self.sonia_model).__name__:
-            initial=np.array([s[0][:3] for s in self.sonia_model.features])
-            l_length=np.sum(initial=='l_h')
-            plt.plot(np.arange(l_length),self.sonia_model.model_marginals[initial=='l_h'],label='POST marginals',alpha=0.9)
-            plt.plot(np.arange(l_length),self.sonia_model.data_marginals[initial=='l_h'],label='DATA marginals',alpha=0.9)
-            plt.plot(np.arange(l_length),self.sonia_model.gen_marginals[initial=='l_h'],label='GEN marginals',alpha=0.9)
-            l_length=np.sum(initial=='l_l')
-            plt.plot(np.arange(l_length),self.sonia_model.model_marginals[initial=='l_l'],'--',color='C0',alpha=0.9)
-            plt.plot(np.arange(l_length),self.sonia_model.data_marginals[initial=='l_l'],'--',color='C1',alpha=0.9)
-            plt.plot(np.arange(l_length),self.sonia_model.gen_marginals[initial=='l_l'],'--',color='C2',alpha=0.9)         
-        else:
-            plt.plot(np.arange(l_length),self.sonia_model.model_marginals[:l_length],label='POST marginals',alpha=0.9)
-            plt.plot(np.arange(l_length),self.sonia_model.data_marginals[:l_length],label='DATA marginals',alpha=0.9)
-            plt.plot(np.arange(l_length),self.sonia_model.gen_marginals[:l_length],label='GEN marginals',alpha=0.9)
-
-        plt.xticks(rotation='vertical')
-        plt.grid()
-        plt.legend()
-        plt.title('CDR3 LENGTH DISTRIBUTION',fontsize=20)
-        plt.subplot(122)
-        order=np.argsort(j_model_marginals)[::-1]
-        plt.scatter(np.array(j_genes)[order],j_model_marginals[order],label='POST marginals',alpha=0.9)
-        plt.scatter(np.array(j_genes)[order],j_data_marginals[order],label='DATA marginals',alpha=0.9)
-        plt.scatter(np.array(j_genes)[order],j_gen_marginals[order],label='GEN marginals',alpha=0.9)
-
-        plt.xticks(rotation='vertical')
-        plt.grid()
-        plt.legend()
-        plt.title('J USAGE DISTRIBUTION',fontsize=20)
-        plt.tight_layout()
+        ax_j = plt.subplot(122)
+        df_j = df[df.index.str[0] == 'j'].sort_values(
+            'model_marginal', ascending=False
+        )
+        for label, marg_type in zip(labels, marg_types):
+            ax_j.scatter(
+                df_j.index.values, df_j[f'{marg_type}_marginal'].values,
+                label=label, alpha=0.9, edgecolor='k', linewidth=0.75,
+                zorder=10
+            )
+        ax_j.tick_params(rotation=90, axis='x')
+        ax_j.grid()
+        ax_j.legend(framealpha=1, fontsize=12)
+        ax_j.set_title('J USAGE DISTRIBUTION',fontsize=20)
+        ax_j.set_xlim(-1, len(df_j))
+        fig.tight_layout()
         if save_name is not None:
             fig.savefig(save_name.split('.')[0]+'_jl.'+save_name.split('.')[1])
 
-        fig=plt.figure(figsize=(16,4))
-        order=np.argsort(v_model_marginals)[::-1]
-        plt.scatter(np.array(v_genes)[order],v_model_marginals[order],label='POST marginals',alpha=0.9)
-        plt.scatter(np.array(v_genes)[order],v_data_marginals[order],label='DATA marginals',alpha=0.9)
-        plt.scatter(np.array(v_genes)[order],v_gen_marginals[order],label='GEN marginals',alpha=0.9)
-
-        plt.xticks(rotation='vertical')
-        plt.grid()
-        plt.legend()
-        plt.title('V USAGE DISTRIBUTION',fontsize=20)
-        plt.tight_layout()        
+        fig, ax_v = plt.subplots(figsize=(16,4))
+        df_v = df[df.index.str[0] == 'v'].sort_values(
+            'model_marginal', ascending=False
+        )
+        for label, marg_type in zip(labels, marg_types):
+            ax_v.scatter(
+                df_v.index.values, df_v[f'{marg_type}_marginal'].values,
+                label=label, alpha=0.9, edgecolor='k', linewidth=0.75,
+                zorder=10
+            )
+        ax_v.tick_params(rotation=90, axis='x')
+        ax_v.set_xlim(-1, len(df_v))
+        ax_v.grid()
+        ax_v.legend(framealpha=1, fontsize=12)
+        ax_v.set_title('V USAGE DISTRIBUTION',fontsize=20)
+        fig.tight_layout()
         if save_name is not None:
             fig.savefig(save_name.split('.')[0]+'_v.'+save_name.split('.')[1])
         else: plt.show()
-        
-    def plot_logQ(self,save_name=None):
-        
-        """Plots logQ of data and generated sequences
+
+    def plot_logQ(
+        self,
+        save_name: Optional[str] =None
+    ) -> None:
+        """
+        Plot logQ of data and generated sequences
 
         Parameters
         ----------
-        save_name : str or None
+        save_name : str, optional
             File name to save output figure. If None (default) does not save.
 
+        Returns
+        -------
+        None
         """
         try:
             self.sonia_model.energies_gen
             self.sonia_model.energies_data
         except:
-            self.sonia_model.energies_gen=self.sonia_model.compute_energy(self.sonia_model.gen_seq_features)+np.log(self.sonia_model.Z)
-            self.sonia_model.energies_data=self.sonia_model.compute_energy(self.sonia_model.data_seq_features)+np.log(self.sonia_model.Z)
-        
-        fig=plt.figure(figsize=(8,4))
-        binning=np.linspace(-self.sonia_model.max_energy_clip-1,-self.sonia_model.min_energy_clip+1,100)
-        hist_gen,bins=np.histogram(-self.sonia_model.energies_gen,binning,density=True)
-        hist_data,bins=np.histogram(-self.sonia_model.energies_data,binning,density=True)
-        plt.plot(bins[:-1],hist_gen,label='generated')
-        plt.plot(bins[:-1],hist_data,label='data')
-        plt.ylabel('density',fontsize=20)
-        plt.xlabel('log Q',fontsize=20)
+            self.sonia_model.energies_gen = (
+                self.sonia_model.compute_energy(self.sonia_model.gen_encoding)
+                + np.log(self.sonia_model.Z)
+            )
+            self.sonia_model.energies_data = (
+                self.sonia_model.compute_energy(self.sonia_model.data_encoding)
+                + np.log(self.sonia_model.Z)
+            )
+
+        fig = plt.figure(figsize=(8,4))
+
+        bins = np.linspace(
+            -self.sonia_model.max_energy_clip - 1,
+            -self.sonia_model.min_energy_clip + 1,
+            100
+        )
+        bin_centers = (bins[:-1] + bins[1:]) / 2
+
+        hist_gen, _ = np.histogram(
+            -self.sonia_model.energies_gen, bins, density=True
+        )
+        hist_data, _ =np.histogram(
+            -self.sonia_model.energies_data, bins, density=True
+        )
+
+        plt.plot(bin_centers, hist_gen, label='generated')
+        plt.plot(bin_centers, hist_data, label='data')
+        plt.ylabel('density', fontsize=20)
+        plt.xlabel('log Q', fontsize=20)
         plt.legend(fontsize=20)
         plt.tight_layout()
+
         if save_name is not None:
             fig.savefig(save_name)
         else: plt.show()
 
+    def plot_ratioQ(
+        self,
+        save_name: Optional[str] = None
+    ) -> None:
+        """
+        Plot the ratio of the marginals in data and pre-selected pool against
+        the energies learned by the model.
 
-    def plot_ratioQ(self,save_name=None):
-        """Plots the ratio of P(Q) in data and pre-selected pool. Useful for model validation. 
+        Useful for model validation.
 
         Parameters
         ----------
-        save_name : str or None
+        save_name : str, optional
             File name to save output figure. If None (default) does not save.
-        """
 
+        Returns
+        -------
+        None
+        """
         try:
             self.sonia_model.energies_gen
             self.sonia_model.energies_data
         except:
-            self.sonia_model.energies_gen=self.sonia_model.compute_energy(self.sonia_model.gen_seq_features)+np.log(self.sonia_model.Z)
-            self.sonia_model.energies_data=self.sonia_model.compute_energy(self.sonia_model.data_seq_features)+np.log(self.sonia_model.Z)
+            self.sonia_model.energies_gen = (
+                self.sonia_model.compute_energy(self.sonia_model.gen_encoding)
+                + np.log(self.sonia_model.Z)
+            )
+            self.sonia_model.energies_data = (
+                self.sonia_model.compute_energy(self.sonia_model.data_encoding)
+                + np.log(self.sonia_model.Z)
+            )
 
-        fig=plt.figure(figsize=(8,8))
-        binning=np.logspace(-11,5,300)
-        a,b=np.histogram(np.exp(-self.sonia_model.energies_gen),binning,density=True)
-        c,d=np.histogram(np.exp(-self.sonia_model.energies_data),binning,density=True)
-        plt.plot([-1,1000],[-1,1000],c='k')
-        plt.xlim([0.001,200])
-        plt.ylim([0.001,200])
-        plt.plot(binning[:-1],np.array(c+1e-30)/np.array(a+1e-30),c='r',linewidth=3,alpha=0.9)
+        fig = plt.figure(figsize=(8,8))
+        bins = np.logspace(-11, 5, 300)
+        bin_centers = (bins[:-1] + bins[1:]) / 2
+        a, _ = np.histogram(
+            np.exp(-self.sonia_model.energies_gen), bins, density=True
+        )
+        c, _ = np.histogram(
+            np.exp(-self.sonia_model.energies_data), bins, density=True
+        )
+        plt.plot([-1, 1000], [-1, 1000], c='k')
+        plt.xlim([0.001, 200])
+        plt.ylim([0.001, 200])
+        plt.plot(bin_centers, (c + 1e-30) / (a+1e-30), c='r', linewidth=3, alpha=0.9)
         plt.xscale('log')
         plt.yscale('log')
         plt.xticks(fontsize=20)
         plt.yticks(fontsize=20)
-        plt.xlabel('Q',fontsize=30)
-        plt.ylabel('$P_{data}(Q)/P_{pre}(Q)$',fontsize=30)
+        plt.xlabel('Q', fontsize=30)
+        plt.ylabel('$P_{data}(Q)/P_{pre}(Q)$', fontsize=30)
         plt.grid()
 
         plt.tight_layout()

--- a/sonnia/plotting.py
+++ b/sonnia/plotting.py
@@ -177,7 +177,7 @@ class Plotter(object):
         None
         """
         df = pd.DataFrame(
-            {'feature': self.sonia_model.features,
+            {'feature': self.sonia_model.features.ravel(),
              'model_marginal': self.sonia_model.model_marginals,
              'gen_marginal': self.sonia_model.gen_marginals,
              'data_marginal': self.sonia_model.data_marginals,

--- a/sonnia/plotting.py
+++ b/sonnia/plotting.py
@@ -121,7 +121,7 @@ class Plotter(object):
 
         if len(self.sonia_model.data_seqs):
             num_data_seqs = len(self.sonia_model.data_seqs)
-            min_for_plot = 10**(np.floor(np.log10(num_data_seqs)))
+            min_for_plot = 10**(-np.ceil(np.log10(num_data_seqs)))
         else:
             min_nonzero_marginal = np.min(self.sonia_model.data_marginals[self.sonia_model.data_marginals != 0])
             min_for_plot = 10**(np.floor(np.log10(min_nonzero_marginal)))

--- a/sonnia/sonia.py
+++ b/sonnia/sonia.py
@@ -857,7 +857,7 @@ class Sonia(object):
             add_gen_seqs=np.array(
                 [[seq,'',''] if isinstance(seq, str) else seq for seq in add_gen_seqs]
             )
-            if len(self.gen_seqs): self.gen_seqs = add_gen_seqs
+            if len(self.gen_seqs) == 0: self.gen_seqs = add_gen_seqs
             else: self.gen_seqs = np.concatenate([self.gen_seqs, add_gen_seqs])
 
         if ((len(add_data_seqs) + len(add_features) + len(remove_features) > 0

--- a/sonnia/sonnia.py
+++ b/sonnia/sonnia.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 # @author: Giulio Isacchini
-from copy import copy
 import itertools
 import logging
 import multiprocessing as mp
@@ -21,13 +20,6 @@ from tqdm import tqdm
 
 from sonnia.sonia import Sonia, GENE_FEATURE_OPTIONS
 from sonnia.utils import gene_to_num_str
-
-#Set input = raw_input for python 2
-try:
-    import __builtin__
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
 
 class SoNNia(Sonia):
     def __init__(
@@ -73,13 +65,13 @@ class SoNNia(Sonia):
 
         length_input = np.max([len(self.features), 1])
 
-        min_clip = copy(self.min_energy_clip)
-        max_clip = copy(self.max_energy_clip)
-        l2_reg = copy(self.l2_reg)
-        l1_reg = copy(self.l1_reg)
-        max_depth = copy(self.max_depth)
-        l_length = copy(self.l_length)
-        vj_length = copy(self.vj_length)
+        min_clip = self.min_energy_clip
+        max_clip = self.max_energy_clip
+        l2_reg = self.l2_reg
+        l1_reg = self.l1_reg
+        max_depth = self.max_depth
+        l_length = self.l_length
+        vj_length = self.vj_length
 
         if initialize:
             input_l = keras.layers.Input(shape=(l_length,), dtype='float32')

--- a/sonnia/sonnia_paired.py
+++ b/sonnia/sonnia_paired.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 @author: Giulio Isacchini
 """
-from copy import copy
 import logging
 import multiprocessing as mp
 import os
@@ -20,13 +19,6 @@ from numpy.typing import NDArray
 
 from sonnia.sonia import GENE_FEATURE_OPTIONS
 from sonnia.sonia_paired import SoniaPaired
-
-#Set input = raw_input for python 2
-try:
-    import __builtin__
-    input = getattr(__builtin__, 'raw_input')
-except (ImportError, AttributeError):
-    pass
 
 class SoNNiaPaired(SoniaPaired):
     def __init__(
@@ -90,9 +82,9 @@ class SoNNiaPaired(SoniaPaired):
 
         self.lengt_encoding = np.max([len(self.features), 1])
 
-        min_clip = copy(self.min_energy_clip)
-        max_clip = copy(self.max_energy_clip)
-        l2_reg = copy(self.l2_reg)
+        min_clip = self.min_energy_clip
+        max_clip = self.max_energy_clip
+        l2_reg = self.l2_reg
 
         if initialize:
             input_l_light = keras.layers.Input(shape=(self.l_length_light,))


### PR DESCRIPTION
# Improvements
- Updated `pyproject.toml` for expected requirements
- plotting functions call `*_encoding` instead of `*_seq_features` in agreement with Sonia classes
- `plot_vjl` uses `pandas` for computing marginals easily and robustly against different model structures and types (i.e., paired models, models using a VJL parameterization, models missing V features, etc.)
- `compute_energy` now has a `chunksize` parameter so a chunk of the sparse encoding is made a dense encoding and then evaluated to mitigate any overloading RAM
- `generate_sequences_post` has a new argument, `max_chunksize` to mitigate RAM issues in case too many post sequences are requested
- Unnecessary copies removed
- Legacy code for python2 removed
- Improved typing and docstrings here and there