### PR TITLE
Fixed filtering and loading gen_seqs for ppost_model

### DIFF
--- a/sonnia/sonnia.py
+++ b/sonnia/sonnia.py
@@ -26,6 +26,7 @@ class SoNNia(Sonia):
         self,
         *args: Tuple[Any],
         gene_features: str = 'indep_vj',
+        include_aminoacids: bool = True,
         deep: bool = True,
         **kwargs: Dict[str, Any],
     ) -> None:
@@ -33,9 +34,16 @@ class SoNNia(Sonia):
         if gene_features in invalid_gene_features:
             valid_gene_features = f'{GENE_FEATURE_OPTIONS - invalid_gene_features}'[1:-1]
             invalid_gene_features = f'{invalid_gene_features}'[1:-1]
-            raise ValueError(f'gene_features = \'{gene_features}\' is an invalid option '
-                             'when using a deep SoNNia model. Use one of the following '
-                             f'instead: {valid_gene_features}.')
+            raise ValueError(
+                f'gene_features = \'{gene_features}\' is an invalid option '
+                'when using a SoNNia model. Use one of the following '
+                f'instead: {valid_gene_features}.'
+            )
+
+        if not include_aminoacids:
+            raise ValueError(
+                'include_aminoacids must be True for a SoNNia model.'
+            )
 
         self.deep = deep
         Sonia.__init__(self, *args, gene_features=gene_features, **kwargs)

--- a/sonnia/sonnia_paired.py
+++ b/sonnia/sonnia_paired.py
@@ -25,6 +25,7 @@ class SoNNiaPaired(SoniaPaired):
         self,
         *args: Tuple[Any],
         gene_features: str = 'indep_vj',
+        include_aminoacids: bool = True,
         across_chain_features: Optional[Iterable[str]] = None,
         independent_chains: bool = False,
         min_energy_clip: int = -10,
@@ -34,16 +35,24 @@ class SoNNiaPaired(SoniaPaired):
         **kwargs: Dict[str, Any]
     ) -> None:
         invalid_gene_features = {'vjl', 'none'}
-        if deep:
-            if gene_features in invalid_gene_features:
-                valid_gene_features = f'{GENE_FEATURE_OPTIONS - invalid_gene_features}'[1:-1]
-                invalid_gene_features = f'{invalid_gene_features}'[1:-1]
-                raise ValueError(f'gene_features = \'{gene_features}\' is an invalid option '
-                                 'when using a deep SoNNiaPaired model. Use one of the '
-                                 f'following instead: {valid_gene_features}.')
-            if across_chain_features is not None:
-                raise RuntimeError('across_chain_features must be None '
-                                   'when using a deep SonniaPaired model.')
+        if gene_features in invalid_gene_features:
+            valid_gene_features = f'{GENE_FEATURE_OPTIONS - invalid_gene_features}'[1:-1]
+            invalid_gene_features = f'{invalid_gene_features}'[1:-1]
+            raise ValueError(
+                f'gene_features = \'{gene_features}\' is an invalid option '
+                'when using a SoNNiaPaired model. Use one of the '
+                f'following instead: {valid_gene_features}.'
+            )
+
+        if across_chain_features is not None:
+            raise RuntimeError('across_chain_features must be None '
+                               'when using a SonniaPaired model.')
+
+        if not include_aminoacids:
+            raise ValueError(
+                'include_aminoacids must be True for a SoNNiaPaired model.'
+            )
+
 
         self.deep = deep
         self.independent_chains = independent_chains


### PR DESCRIPTION
# Improvements
- gen_seqs are properly loaded when a ppost_model is specified (previously it loaded it as data_seqs--a typo)
- filter_seqs converts V and J genes to num_strs
- data_seqs and gen_seqs given by the user in initializing a model object are preprocessed by default.
    - gen_seqs need not be from a pgen_model or can be loaded from a .csv file this way