### PR TITLE
Created SoniaDataset for mini-batching.

### DIFF
--- a/sonnia/plotting.py
+++ b/sonnia/plotting.py
@@ -345,18 +345,14 @@ class Plotter(object):
         -------
         None
         """
-        try:
-            self.sonia_model.energies_gen
-            self.sonia_model.energies_data
-        except:
-            self.sonia_model.energies_gen = (
-                self.sonia_model.compute_energy(self.sonia_model.gen_encoding)
-                + np.log(self.sonia_model.Z)
-            )
-            self.sonia_model.energies_data = (
-                self.sonia_model.compute_energy(self.sonia_model.data_encoding)
-                + np.log(self.sonia_model.Z)
-            )
+        self.sonia_model.energies_gen = (
+            self.sonia_model.compute_energy(self.sonia_model.gen_encoding)
+            + np.log(self.sonia_model.Z)
+        )
+        self.sonia_model.energies_data = (
+            self.sonia_model.compute_energy(self.sonia_model.data_encoding)
+            + np.log(self.sonia_model.Z)
+        )
 
         fig = plt.figure(figsize=(8,8))
         bins = np.logspace(-11, 5, 300)

--- a/sonnia/plotting.py
+++ b/sonnia/plotting.py
@@ -363,10 +363,15 @@ class Plotter(object):
         c, _ = np.histogram(
             np.exp(-self.sonia_model.energies_data), bins, density=True
         )
+
+        ratio = np.zeros(shape=len(c)) + np.nan
+        ratio = np.divide(c, a, where=a > 0, out=ratio)
+        ratio[(c > 0) & (a == 0)] = 1e9
+
         plt.plot([-1, 1000], [-1, 1000], c='k')
         plt.xlim([0.001, 200])
         plt.ylim([0.001, 200])
-        plt.plot(bin_centers, (c + 1e-30) / (a+1e-30), c='r', linewidth=3, alpha=0.9)
+        plt.plot(bin_centers, ratio, c='r', linewidth=3, alpha=0.9)
         plt.xscale('log')
         plt.yscale('log')
         plt.xticks(fontsize=20)

--- a/sonnia/sonia.py
+++ b/sonnia/sonia.py
@@ -26,6 +26,7 @@ from numpy.typing import ArrayLike, NDArray
 import scipy.sparse as sparse
 from tqdm import tqdm
 
+from sonnia.sonia_dataset import SoniaDataset
 from sonnia.utils import (
     CSV_READER_PARAMS, compute_pgen_expand, compute_pgen_expand_novj, define_pgen_model,
     filter_seqs, gene_to_num_str, get_model_dir, partial_joint_marginals
@@ -557,7 +558,8 @@ class Sonia(object):
         seed: Optional[int | np.random.Generator | np.random.BitGenerator | np.random.SeedSequence] = None,
         validation_split: float = 0.2,
         verbose: int = 0,
-        set_gauge: bool = True
+        set_gauge: bool = True,
+        sampling: str = 'unbalanced'
     ) -> None:
         """
         Infer model parameters, i.e. energies for each model feature.
@@ -578,6 +580,11 @@ class Sonia(object):
             Output the training progress.
         set_gauge : bool, default True
             Set the gauge for the model output.
+        sampling : str, default 'unbalanced'
+            How the data seqs and gen seqs should be loaded into mini-batches.
+            If 'legacy' the sonnia.SoniaDataset class will not be used, and
+            a data sequence always appearing in a mini-batch will not be guaranteed.
+            See sonnia.SoniaDataset for other sampling options.
 
         Returns
         -------
@@ -590,7 +597,10 @@ class Sonia(object):
 
         if initialize:
             self.X = sparse.vstack((self.data_encoding, self.gen_encoding))
-            self.Y = np.zeros(self.data_encoding.shape[0] + self.gen_encoding.shape[0])
+            self.Y = np.zeros(
+                self.data_encoding.shape[0] + self.gen_encoding.shape[0],
+                dtype=np.int8
+            )
             self.Y[self.data_encoding.shape[0]:] += 1
 
             shuffle = rng.permutation(self.X.shape[0])
@@ -607,26 +617,61 @@ class Sonia(object):
             TerminateOnNaN(),
         ]
 
-        if hasattr(self, 'split_encoding'):
-            input_data = self.split_encoding(self.X.toarray())
+        if sampling == 'legacy':
+            if hasattr(self, 'split_encoding'):
+                input_data = self.split_encoding(self.X.toarray())
+            else:
+                input_data = self.X.toarray()
+            self.learning_history = self.model.fit(
+                input_data, self.Y, epochs=epochs, batch_size=batch_size,
+                validation_split=validation_split, verbose=verbose, callbacks=callbacks,
+            )
         else:
-            input_data = self.X.toarray()
-        self.learning_history = self.model.fit(
-            input_data, self.Y, epochs=epochs, batch_size=batch_size,
-            validation_split=validation_split, verbose=verbose, callbacks=callbacks,
-        )
+            if validation_split < 0 or validation_split >= 1:
+                raise ValueError('validation_split must be in [0, 1).')
+            if validation_split == 0:
+                validation_data = None
+            else:
+                if hasattr(self, 'split_encoding'):
+                    split_encoding = self.split_encoding
+                else:
+                    split_encoding = None
+
+                val_end_idx = int(validation_split * len(self.Y))
+                val_x, val_y = self.X[:val_end_idx], self.Y[:val_end_idx]
+                train_x, train_y = self.X[val_end_idx:], self.Y[val_end_idx:]
+
+                child_rngs = [
+                    np.random.default_rng(child_state)
+                    for child_state in rng.bit_generator._seed_seq.spawn(2)
+                ]
+
+                train_generator = SoniaDataset(
+                    train_x, train_y, sampling, batch_size, seed=child_rngs[0],
+                    split_encoding=split_encoding,
+                )
+                val_generator = SoniaDataset(
+                    val_x, val_y, sampling, batch_size, seed=child_rngs[1],
+                    split_encoding=split_encoding,
+                )
+
+                self.learning_history = self.model.fit(
+                    train_generator, validation_data=val_generator, epochs=epochs,
+                    batch_size=batch_size, verbose=verbose, callbacks=callbacks,
+                )
+
         self.likelihood_train = -np.array(self.learning_history.history['_likelihood']) * 1.44
         self.likelihood_test = -np.array(self.learning_history.history['val__likelihood']) * 1.44
         self.model_params = self.model.get_weights()
 
         if np.isnan(self.likelihood_train).any() or np.isnan(self.likelihood_test).any():
             raise RuntimeError('The training or validation likelihood history '
-                               'contains nans. This occurs if a batch contains '
+                               'contains nans. This occurs if a mini-batch contains '
                                'data_seqs only or gen_seqs only. Consider '
                                'increasing the batch_size so that it is certain '
-                               'that a batch includes both data_seqs and gen_seqs '
-                               'or consider changing how many generated sequences '
-                               'you are using.')
+                               'that a batch includes both data_seqs and gen_seqs, '
+                               'changing how many generated sequences you are using, '
+                               'or using the SoniaDataset loader.')
 
         logging.info('Finished training.')
 
@@ -745,11 +790,13 @@ class Sonia(object):
         y_true,
         y_pred
     ) -> float:
-        """Loss function for keras training.
-            We assume a model of the form P(x)=exp(-E(x))P_0(x)/Z.
-            We minimize the neg-loglikelihood: <-logP> = log(Z) - <-E>.
-            Normalization of P gives Z=<exp(-E)>_{P_0}.
-            We fix the gauge by adding the constraint (Z-1)**2 to the likelihood.
+        """
+        Loss function for keras training.
+
+        We assume a model of the form P(x)=exp(-E(x))P_0(x)/Z.
+        We minimize the neg-loglikelihood: <-logP> = log(Z) - <-E>.
+        Normalization of P gives Z=<exp(-E)>_{P_0}.
+        We fix the gauge by adding the constraint (Z-1)**2 to the likelihood.
         """
         y = ko.cast(y_true, dtype='bool')
         data = ko.mean(y_pred[ko.logical_not(y)])
@@ -763,10 +810,15 @@ class Sonia(object):
     ) -> float:
         """
         This is the "I" loss in the arxiv paper with added regularization
+
+        A likelihood value of nan means no data sequences were present in
+        the mini-batch.
         """
         y = ko.cast(y_true, dtype='bool')
         data = ko.mean(y_pred[ko.logical_not(y)])
         gen = ko.logsumexp(-y_pred[y]) - ko.log(ko.sum(y_true))
+        #data = ko.nan_to_num(ko.mean(y_pred[ko.logical_not(y)]))
+        #gen = ko.nan_to_num(ko.logsumexp(-y_pred[y]) - ko.log(ko.sum(y_true)), neginf=0)
         return gen + data
 
     def update_model(
@@ -905,10 +957,10 @@ class Sonia(object):
 
     def add_generated_seqs(
         self,
-        num_gen_seqs: int = 0,
+        num_gen_seqs,
         reset_gen_seqs: bool = True,
         add_error: bool = False,
-        error_rate: Optional[int] = None
+        error_rate: Optional[int] = None,
     ) -> None:
         """Generates MonteCarlo sequences for gen_seqs using OLGA.
         Only generates seqs from a V(D)J model. Requires the OLGA package
@@ -935,8 +987,9 @@ class Sonia(object):
             Features gen_seqs have been projected onto.
         """
         logging.info(f'Generating {num_gen_seqs} using the pgen model in {self.pgen_dir}.')
-        seqs = self.generate_sequences_pre(num_gen_seqs, nucleotide=False,
-                                           add_error=add_error, error_rate=error_rate)
+        seqs = self.generate_sequences_pre(
+            num_gen_seqs, nucleotide=False, add_error=add_error, error_rate=error_rate
+        )
         if reset_gen_seqs: self.gen_seqs = []
         self.update_model(add_gen_seqs=seqs)
 
@@ -1270,7 +1323,7 @@ class Sonia(object):
 
     def generate_sequences_pre(
         self,
-        num_seqs: int = 1,
+        num_seqs: int,
         nucleotide: bool = False,
         error_rate: Optional[int] = None,
         add_error: bool = False,
@@ -1334,6 +1387,16 @@ class Sonia(object):
             return seqs
         else:
             return seqs[:, :-1]
+
+#        if seed is None:
+#            seed = self.rng
+#
+#        seqs = rg.generate_pgen_seqs(
+#            self.pgen_dir, num_seqs, seed, processes=self.processes)
+#
+#        if nucleotide:
+#            return seqs
+#        return seqs[:, :-1]
 
     def generate_sequences_post(
         self,

--- a/sonnia/sonia_dataset.py
+++ b/sonnia/sonia_dataset.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Montague, Zachary
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Script containing the SoniaDataset class for loading data into mini-batches.
+"""
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import keras
+import keras.ops as ko
+import numpy as np
+from numpy.typing import NDArray
+import scipy.sparse as sparse
+
+class SoniaDataset(keras.utils.PyDataset):
+    """
+    A Dataset class for ensuring both gen seqs and data seqs appear in a mini-batch.
+    Options allow there to be the original imbalance as well as sampling schemes for
+    balancing the two datasets in mini-batches using over- and undersampling.
+
+    Attributes
+    ----------
+    x : numpy.ndarray of numpy.int8 or scipy.sparse.csr_array
+        The dense or sparse one-hot feature encoding.
+    y : numpy.ndarray of numpy.int8
+        The labels for whether the feature comes from data (0) or gen (1).
+    batch_size : int
+        How big a mini-batch is.
+    shuffle : bool
+        Whether the features and labels should be shuffled after each epoch.
+    rng : numpy.random.Generator
+        A random number generator.
+    split_encoding : callable
+        A function for SoNNia models for splitting the encoding into separate
+        length, amino acid, and gene feature arrays.
+    sparse_input : bool
+        If the encoding of features is a scipy.sparse.csr_array.
+    where_class_0 : numpy.ndarray of numpy.int32
+        The indices of data features in x.
+    where_class_1 : numpy.ndarray of numpy.int32
+        The indices of gen features in x.
+    class_0_size : int
+        The amount of data seqs.
+    class_1_size : int
+        The amount of gen seqs.
+    bigger_size : int
+        The size of the majority class.
+    smaller_size : int
+        The size of the minority class.
+    batch_constraint : int
+        The constraint on the number of mini-batches.
+    sampling : str
+        The type of sampling using to construct mini-batches.
+    class_0_batch : int
+        The number of class 0 datapoints when using imbalanced sampling.
+    class_1_batch : int
+        The number of class 1 datapoints when using imbalanced sampling.
+
+    Methods
+    -------
+    __getitem__(index)
+        Return the mini-batch indexed by index.
+    __len__()
+        Return the number of mini-batches in an epoch.
+    on_epoch_end_oversample()
+        Update the indices for the next epoch when oversampling the minority class.
+    on_epoch_end_undersample()
+        Update the indices for the next epoch when undersampling the majority class.
+    on_epoch_end()
+        How to update the indices (determined by the sampling scheme).
+    """
+    def __init__(
+        self,
+        x: NDArray[np.int8],
+        y: NDArray[np.int8],
+        sampling: str,
+        batch_size: int = 512,
+        shuffle: bool = True,
+        seed: Optional[int | np.random.Generator | np.random.BitGenerator | np.random.SeedSequence] = None,
+        split_encoding: Optional[Callable] = None,
+        **kwargs: Dict[str, Any],
+    ) -> None:
+        """
+        Initialize a SoniaDataset object.
+
+        Parameters
+        ----------
+        x : numpy.ndarray of numpy.int8
+            The one-hot encoded sequence features.
+        y : numpy.ndarray of numpy.int8
+            The labels of the data.
+        sampling : str
+            Options are 'undersample' (undersample the majority class each epoch).
+            'oversample' (oversample the minority class each epoch), or 'unbalanced'
+            (use the original proportion of data and gen but ensure that both data
+            and gen appear in each mini-batch).
+        batch_size : int, default 512
+            The size of the mini-batch.
+        shuffle : bool, default True
+            After every epoch, reshuffle the data.
+        seed : int or np.random.Generator or np.random.BitGenerator or np.random.SeedSequence, optional
+            Sets random seed.
+        **kwargs
+            Keyword arguments to keras.utils.PyDataset.
+        """
+        super().__init__(**kwargs)
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.rng = np.random.default_rng(seed)
+        self.split_encoding = split_encoding
+
+        self.sparse_input = isinstance(x, sparse.csr_array)
+
+        self.x = x
+        self.y = y
+
+        self.where_class_0 = ko.where(y == 0)[0].numpy()
+        self.where_class_1 = ko.where(y == 1)[0].numpy()
+
+        self.class_0_size = self.where_class_0.shape[0]
+        if self.class_0_size == 0:
+            raise RuntimeError('No data seqs loaded into the SoniaDataset.')
+
+        self.class_1_size = self.where_class_1.shape[0]
+        if self.class_1_size == 0:
+            raise RuntimeError('No gen seqs loaded into the SoniaDataset.')
+
+        if self.class_0_size > self.class_1_size:
+            self.bigger_size = self.class_0_size
+            self.smaller_size = self.class_1_size
+            self.majority_class = 0
+        else:
+            self.bigger_size = self.class_1_size
+            self.smaller_size = self.class_0_size
+            self.majority_class = 1
+
+        self.sampling = sampling
+        if self.sampling == 'undersample':
+            self.batch_constraint = self.smaller_size * 2
+            self.on_epoch_end = self.on_epoch_end_shuffle
+        elif self.sampling == 'oversample':
+            self.batch_constraint = self.bigger_size * 2
+            self.on_epoch_end = self.on_epoch_end_oversample
+        elif self.sampling == 'unbalanced':
+            self.batch_constraint = self.class_0_size + self.class_1_size
+            self.class_0_batch = int(
+                self.class_0_size / (self.class_0_size + self.class_1_size) * self.batch_size
+            )
+
+            if self.class_0_batch == 0:
+                raise RuntimeError(
+                    'The classes are too imbalanced. Not every batch will contain '
+                    'a data sequence. One possible way to mitigate this is increasing '
+                    'the batch_size.'
+                )
+
+
+            self.class_1_batch = int(
+                self.class_1_size / (self.class_0_size + self.class_1_size) * self.batch_size
+            )
+            if self.class_1_batch == 0:
+                raise RuntimeError(
+                    'The classes are too imbalanced. Not every batch will contain '
+                    'a gen sequence. One possible way to mitigate this is increasing '
+                    'the batch_size.'
+                )
+
+            self.on_epoch_end = self.on_epoch_end_shuffle
+        else:
+            raise ValueError(
+                'sampling must be \'undersample\', \'oversample\', or \'unbalanced\'.'
+            )
+
+        self.on_epoch_end()
+
+    def __getitem__(
+        self,
+        index: int
+    ) -> Tuple[NDArray[np.int8] | List[NDArray[np.int8]], NDArray[np.int8]]:
+        """
+        Return a mini-batch which is guaranteed to include both gen and data seqs.
+
+        For the undersample stratgey, there are batches indexed beyond the object's
+        length which contain only one class. In practice, keras does not index beyond
+        the SoniaDataset object's length, so this isn't a problem at the moment for
+        ensuring both data and gen seqs appear in a mini-batch.
+
+        Parameters
+        ----------
+        index : int
+            The index of the mini-batch for an epoch.
+
+        Returns
+        -------
+        x : numpy.ndarray of numpy.int8 or list of numpy.ndarray of numpy.int8
+            The features of class 0 and class 1 data.
+        y : numpy.ndarray of numpy.int8
+            The labels denoting which features come from class 0 or class 1 data.
+        """
+        if self.sampling != 'unbalanced':
+            start_idx = index * self.batch_size // 2
+            end_idx = start_idx + self.batch_size // 2
+            indices_0 = self.class_0_indices[start_idx:end_idx]
+            indices_1 = self.class_1_indices[start_idx:end_idx]
+        else:
+            start_idx_0 = index * self.class_0_batch
+            end_idx_0 = start_idx_0 + self.class_0_batch
+            start_idx_1 = index * self.class_1_batch
+            end_idx_1 = start_idx_1 + self.class_1_batch
+            indices_0 = self.class_0_indices[start_idx_0:end_idx_0]
+            indices_1 = self.class_1_indices[start_idx_1:end_idx_1]
+
+        # It is faster to concatenate indices than it is to concatenate arrays
+        # of large two-dimensional arrays of features.
+        batch_indices = np.concatenate((
+            self.where_class_0[indices_0], self.where_class_1[indices_1]
+        ))
+
+        if self.sparse_input:
+            x = self.x[batch_indices].toarray()
+        else:
+            x = self.x[batch_indices]
+
+        y = self.y[batch_indices]
+
+        if self.split_encoding is not None:
+            x = self.split_encoding(x)
+        return x, y
+
+    def __len__(
+        self
+    ) -> int:
+        """
+        Return the number of mini-batches per epoch.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        int
+            The number of mini-batches per epoch. If undersampling the majority
+            class, the number of mini-batches is set by the minority class, and
+            vice versa for oversampling. If unbalanced sampling, the number of
+            mini-batches is set by the total number of data and gen seqs.
+        """
+        return int(np.ceil(self.batch_constraint / self.batch_size))
+
+    def on_epoch_end_oversample(
+        self
+    ) -> None:
+        """
+        Update the indices for the next epoch.
+
+        For oversampling, the minority class is sampled with replacement each epoch
+        to match the size of the majority class. Shuffling affects only the indices
+        of the majority class.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        if self.majority_class == 1:
+            self.class_0_indices = self.rng.choice(
+                self.class_0_size, size=self.class_1_size
+            )
+            self.class_1_indices = np.arange(self.class_1_size)
+            if self.shuffle == True:
+                self.rng.shuffle(self.class_1_indices)
+        else:
+            self.class_1_indices = self.rng.choice(
+                self.class_1_size, size=self.class_0_size
+            )
+            self.class_0_indices = np.arange(self.class_0_size)
+            if self.shuffle == True:
+                self.rng.shuffle(self.class_0_indices)
+
+    def on_epoch_end_shuffle(
+        self
+    ) -> None:
+        """
+        Update the indices for the next epoch.
+
+        Shuffling affects both minority and majority classes.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        self.class_0_indices = np.arange(self.class_0_size)
+        self.class_1_indices = np.arange(self.class_1_size)
+        if self.shuffle == True:
+            self.rng.shuffle(self.class_0_indices)
+            self.rng.shuffle(self.class_1_indices)

--- a/sonnia/sonnia.py
+++ b/sonnia/sonnia.py
@@ -161,9 +161,9 @@ class SoNNia(Sonia):
         length_encoding = encoding.shape[0]
         enc1 = encoding[:, :self.l_length]
         enc2 = (encoding[:, self.l_length:self.l_length + self.a_length]
-                .reshape(length_encoding, 20, 50).swapaxes(1, 2))
+                .reshape(length_encoding, 20, self.max_depth * 2).swapaxes(1, 2))
         enc3 = encoding[:, self.l_length + self.a_length:]
-        return [enc1, enc2, enc3]
+        return enc1, enc2, enc3
 
     def _load_features_and_model(
         self,

--- a/sonnia/sonnia_paired.py
+++ b/sonnia/sonnia_paired.py
@@ -189,7 +189,7 @@ class SoNNiaPaired(SoniaPaired):
 
         encv_l = encoding[:, l_length_total + a_length_total:l_length_total + a_length_total + self.vj_length_light]
         encv_h = encoding[:, l_length_total + a_length_total + self.vj_length_light:]
-        return [encl_l, encl_h, enca_l, enca_h, encv_l, encv_h]
+        return encl_l, encl_h, enca_l, enca_h, encv_l, encv_h
 
     def _loss(
         self,


### PR DESCRIPTION
# Improvements
- Created `SoniaDataset` for ensuring mini-batching contains both generated and data sequences
- `Sonia.infer_selection` has a new `sampling` argument for the `SoniaDataset` mini-batch loader. `sampling=legacy` uses the previous method of creating mini-batches, letting keras do all the work.
- Changed `plotter.plot_ratioQ` to compute energies always
- Changed `SoNNia.split_encoding` and `SoNNiaPaired.split_encoding` not to output the split encoding as a list