### PR TITLE
Torch backend

### DIFF
--- a/sonnia/__init__.py
+++ b/sonnia/__init__.py
@@ -2,7 +2,6 @@ from sonnia.sonia import Sonia
 from sonnia.sonnia import SoNNia
 from sonnia.sonia_paired import SoniaPaired
 from sonnia.sonnia_paired import SoNNiaPaired
-
 from sonnia.plotting import Plotter
 
 from sonnia.utils import filter_seqs

--- a/sonnia/__main__.py
+++ b/sonnia/__main__.py
@@ -1,8 +1,6 @@
 import os
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 import typer
 import pandas as pd
-import sonnia.sonnia
 from sonnia.sonia import Sonia
 from sonnia.sonnia import SoNNia
 from typing import Optional
@@ -78,10 +76,10 @@ def infer(
     infile_gen: Optional[str] = typer.Option(None, "--infile_gen", help="Path to input file for generated sequences"),
 ):
     """Evaluate sequences using a generative model."""
-    
+
     junction_column =  "amino_acid" if ".csv" in infile else "junction_aa"
     delimiter = "\t" if ".tsv" in infile else "," if ".csv" in infile else ";"
-    
+
     # Load input data
     typer.echo("Loading input data...")
     try:

--- a/sonnia/classifiers.py
+++ b/sonnia/classifiers.py
@@ -1,6 +1,8 @@
+import os 
+os.environ["KERAS_BACKEND"] = "torch" # use torch backend
 import keras
 import numpy as np
-from sonia.sonia_leftpos_rightpos import SoniaLeftposRightpos
+from sonnia import Sonia
 from tqdm import tqdm
 
 
@@ -11,15 +13,14 @@ class Linear:
     """
 
     def __init__(
-        self, sonia_model=None, include_indep_genes=False, include_joint_genes=True
+        self, 
+        sonia_model=None, 
+        chain_type='human_T_beta',
     ):
         if sonia_model is not None:
             self.sonia_model = sonia_model
         else:
-            self.sonia_model = SoniaLeftposRightpos(
-                include_indep_genes=include_indep_genes,
-                include_joint_genes=include_joint_genes,
-            )
+            self.sonia_model = Sonia(pgen_model=chain_type)
         self.input_size = len(self.sonia_model.features)
         self.update_model_structure(initialize=True)
 
@@ -67,15 +68,9 @@ class SoniaRatio:
     Sonia classifier as log likelihood ratio.
     """
 
-    def __init__(self, include_indep_genes=False, include_joint_genes=True):
-        self.sonia_model_positive = SoniaLeftposRightpos(
-            include_indep_genes=include_indep_genes,
-            include_joint_genes=include_joint_genes,
-        )
-        self.sonia_model_negative = SoniaLeftposRightpos(
-            include_indep_genes=include_indep_genes,
-            include_joint_genes=include_joint_genes,
-        )
+    def __init__(self, chain_type="human_T_beta"):
+        self.sonia_model_positive = Sonia(chain_type=chain_type)
+        self.sonia_model_negative = Sonia(chain_type=chain_type)
 
     def fit(self, x, y, val_split=0, epochs=30, gen_seqs=None):
         sel = y[:, 0].astype(np.bool)

--- a/sonnia/sonia.py
+++ b/sonnia/sonia.py
@@ -497,7 +497,10 @@ class Sonia:
             if hasattr(self, "split_encoding"):
                 dense_encoding = self.split_encoding(dense_encoding)
             try:
-                energies_slice = self.model(dense_encoding)[:, 0].detach().numpy()
+                if keras.backend.backend() == "tensorflow":
+                    energies_slice = self.model(dense_encoding).numpy()[:, 0]
+                else:
+                    energies_slice = self.model(dense_encoding)[:, 0].detach().numpy()
             except Exception as e:
                 if "Failed copying" in str(e):
                     raise RuntimeError(
@@ -1253,12 +1256,11 @@ class Sonia:
                         + "\n"
                     )
 
-        self.model.save(os.path.join(save_dir, "model.keras"))
+        self.model.save_weights(os.path.join(save_dir, "model.weights.h5"))
         self._save_pgen_model(save_dir)
 
     def _save_pgen_model(self, save_dir: str) -> None:
         import shutil
-
         shutil.copy2(os.path.join(self.pgen_dir, "model_params.txt"), save_dir)
         shutil.copy2(os.path.join(self.pgen_dir, "model_marginals.txt"), save_dir)
         shutil.copy2(os.path.join(self.pgen_dir, "V_gene_CDR3_anchors.csv"), save_dir)
@@ -1281,10 +1283,12 @@ class Sonia:
         files_in_dir = set(os.listdir(self.ppost_dir))
 
         if "NN" in type(self).__name__:
+            if "model.weights.h5" in files_in_dir:
+                ppost_files += ("model.weights.h5",)
             if "model.h5" in files_in_dir:
                 ppost_files += ("model.h5",)
-            else:
-                ppost_files += ("model.keras",)
+                raise RuntimeError("model.h5 files no longer supported. "
+                                   "Install a previous version of the software.")
 
         missing_files = set(ppost_files) - files_in_dir
 
@@ -1307,11 +1311,6 @@ class Sonia:
                 )
 
         feature_file = os.path.join(self.ppost_dir, "features.tsv")
-        try: 
-            model_file = os.path.join(self.ppost_dir, "model.keras")
-        except:
-            model_file = os.path.join(self.ppost_dir, "model.h5")
-
         data_seq_file = os.path.join(self.ppost_dir, "data_seqs.tsv")
         gen_seq_file = os.path.join(self.ppost_dir, "gen_seqs.tsv")
         log_file = os.path.join(self.ppost_dir, "log.txt")
@@ -1350,8 +1349,12 @@ class Sonia:
                     self.likelihood_test.append(float(test_val))
                 except:
                     continue
-
-        self._load_features_and_model(feature_file, model_file, verbose)
+        weights_file = os.path.join(self.ppost_dir, "model.weights.h5")
+        #try: 
+        #    model_file = os.path.join(self.ppost_dir, "model.keras")
+        #except:
+        #    model_file = os.path.join(self.ppost_dir, "model.h5")
+        self._load_features_and_model(feature_file, weights_file, verbose)
 
         if not load_seqs:
             return
@@ -1434,55 +1437,16 @@ class Sonia:
         self.gen_marginals = np.array(gen_marginals)
         self.model_marginals = np.array(model_marginals)
         self.feature_dict = {tuple(f): i for i, f in enumerate(self.features)}
-
+        self.update_model_structure(initialize=True)
         if k == 1:
             feature_energies = np.array(energies).reshape(len(self.features), 1)
-            self.update_model_structure(initialize=True)
             self.model.set_weights([feature_energies])
             self.model_params = self.model.get_weights()
-
         else:
-            try:
-                self.model = keras.models.load_model(
-                    model_file,
-                    custom_objects={
-                        "loss": self._loss,
-                        "likelihood": self._likelihood,
-                        "clip": ko.clip,
-                    },
-                    compile=False,
-                )
-            except Exception as e:
-                if "Unknown layer" in str(e):
-                    paired_str = "Paired" if "Paired" in type(self).__name__ else ""
-                    raise RuntimeError(
-                        "The loaded model structure is supposed to be for "
-                        f"a SoNNia{paired_str} model, but a Sonia{paired_str} "
-                        "model is trying to be initialized. Try loading "
-                        f"the model using the SoNNia{paired_str} class instead."
-                    )
-                else:
-                    raise e
-
-            if len(self.model.layers) > 3:
-                paired_str = "Paired" if "Paired" in type(self).__name__ else ""
-                raise RuntimeError(
-                    "The loaded model structure is supposed to be "
-                    f"for a SoNNia{paired_str} model, but a Sonia{paired_str} "
-                    "model is trying to be initialized. Try loading "
-                    f"the model using the SoNNia{paired_str} class instead."
-                )
-
-            self.optimizer = keras.optimizers.RMSprop()
-            self.model.compile(
-                optimizer=self.optimizer, loss=self._loss, metrics=[self._likelihood]
-            )
+            self.model.load_weights(model_file)
 
     def load_pgen_model(self) -> None:
-        """
-        Load olga model.
-        """
-        # Load generative model
+        """Load olga model."""
         (
             self.genomic_data,
             self.generative_model,

--- a/sonnia/sonia_dataset.py
+++ b/sonnia/sonia_dataset.py
@@ -17,6 +17,8 @@
 """Script containing the SoniaDataset class for loading data into mini-batches."""
 
 from typing import Any, Callable, Dict, List, Optional, Tuple
+import os 
+os.environ["KERAS_BACKEND"] = "torch" # use torch backend
 
 import keras
 import keras.ops as ko

--- a/sonnia/sonia_paired.py
+++ b/sonnia/sonia_paired.py
@@ -7,7 +7,8 @@ import multiprocessing as mp
 import os
 from typing import *
 
-logging.getLogger("tensorflow").disabled = True
+#logging.getLogger("tensorflow").disabled = True
+os.environ["KERAS_BACKEND"] = "torch" # use torch backend
 
 import numpy as np
 from tqdm import tqdm

--- a/sonnia/sonnia.py
+++ b/sonnia/sonnia.py
@@ -5,8 +5,10 @@ import logging
 import os
 from typing import *
 
-logging.getLogger("tensorflow").disabled = True
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+#logging.getLogger("tensorflow").disabled = True
+#os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
+os.environ["KERAS_BACKEND"] = "torch" # use torch backend
 
 import keras
 import keras.ops as ko
@@ -145,7 +147,12 @@ class SoNNia(Sonia):
         )(output_layer)
 
         self.model = keras.models.Model(inputs=input_layer, outputs=clipped_out)
-        self.optimizer = keras.optimizers.RMSprop()
+        if self.optimizer_name == "adam":
+            self.optimizer = keras.optimizers.Adam()
+        elif self.optimizer_name == "rmsprop":
+            self.optimizer = keras.optimizers.RMSprop()
+        else:
+            raise RuntimeError(''f"Optimizer {self.optimizer_name} not recognized.")
 
         if self.objective == "BCE":
             self.model.compile(

--- a/sonnia/sonnia.py
+++ b/sonnia/sonnia.py
@@ -76,6 +76,7 @@ class SoNNia(Sonia):
         max_depth = self.max_depth
         l_length = self.l_length
         vj_length = self.vj_length
+        activation='tanh'
 
         if initialize:
             input_l = keras.layers.Input(shape=(l_length,), dtype="float32")
@@ -90,10 +91,11 @@ class SoNNia(Sonia):
             input_layer = [input_l, input_cdr3, input_vj]
 
             if not self.deep:
-                l = input_l
+                # linear model definition
+                cdr3_length = input_l
                 cdr3 = keras.layers.Flatten()(input_cdr3)
                 vj = input_vj
-                merge = keras.layers.Concatenate()([l, cdr3, vj])
+                merge = keras.layers.Concatenate()([cdr3_length, cdr3, vj])
                 output_layer = keras.layers.Dense(
                     1,
                     use_bias=False,
@@ -102,36 +104,47 @@ class SoNNia(Sonia):
                     kernel_initializer="zeros",
                 )(merge)
             else:
-                # define encodings
-                l = keras.layers.Dense(
-                    10,
-                    activation="tanh",
+                # cdr3 length reduced to dimension 10
+                cdr3_length = keras.layers.Dense(
+                    5,
+                    activation=activation,
                     kernel_initializer="lecun_normal",
                     kernel_regularizer=keras.regularizers.l2(l2_reg),
                 )(input_l)
+
+                # cdr3 processes embeddings, flattens, and reduces to dimension 40
                 cdr3 = EmbedViaMatrix(10)(input_cdr3)
-                cdr3 = keras.layers.Activation("tanh")(cdr3)
                 cdr3 = keras.layers.Flatten()(cdr3)
                 cdr3 = keras.layers.Dense(
                     40,
-                    activation="tanh",
+                    activation=activation,
                     kernel_initializer="lecun_normal",
                     kernel_regularizer=keras.regularizers.l2(l2_reg),
                 )(cdr3)
+
+                # vj reduces to dimension 30
                 vj = keras.layers.Dense(
-                    30,
-                    activation="tanh",
+                    25,
+                    activation=activation,
                     kernel_initializer="lecun_normal",
                     kernel_regularizer=keras.regularizers.l2(l2_reg),
                 )(input_vj)
                 # merge
-                merge = keras.layers.Concatenate()([l, cdr3, vj])
-                h = keras.layers.Dense(
-                    60,
-                    activation="tanh",
-                    kernel_initializer="lecun_normal",
-                    kernel_regularizer=keras.regularizers.l2(l2_reg),
-                )(merge)
+                merge = keras.layers.Concatenate()([cdr3_length, cdr3, vj])
+
+                # 2 residual blocks of size 70
+                for _ in range(2):
+                    h = keras.layers.Dense(
+                        70,
+                        activation=activation,
+                        kernel_initializer="lecun_normal",
+                        kernel_regularizer=keras.regularizers.l2(l2_reg),
+                    )(merge)
+                    merge=keras.layers.Add()([h, merge])
+
+                h= keras.layers.Concatenate()([cdr3_length, cdr3, vj, merge])
+
+
                 output_layer = keras.layers.Dense(
                     1,
                     activation="linear",
@@ -229,29 +242,9 @@ class SoNNia(Sonia):
         self.a_length = np.count_nonzero(initial == "a")
         self.vj_length = np.count_nonzero((initial == "v") | (initial == "j"))
 
-        self.model = keras.models.load_model(
-            model_file,
-            custom_objects={
-                "loss": self._loss,
-                "likelihood": self._likelihood,
-                "EmbedViaMatrix": EmbedViaMatrix,
-                "clip": ko.clip,
-            },
-            compile=False,
-        )
+        self.update_model_structure(initialize=True)
+        self.model.load_weights(model_file)
 
-        if len(self.model.layers) == 3:
-            raise RuntimeError(
-                "The loaded model structure is supposed to be "
-                "for a Sonia model, but a SoNNia "
-                "model is trying to be initialized. Try loading "
-                "the model using the Sonia class instead."
-            )
-
-        self.optimizer = keras.optimizers.RMSprop()
-        self.model.compile(
-            optimizer=self.optimizer, loss=self._loss, metrics=[self._likelihood]
-        )
 
     def set_gauge(self):
         """

--- a/sonnia/sonnia_paired.py
+++ b/sonnia/sonnia_paired.py
@@ -17,7 +17,6 @@ from numpy.typing import NDArray
 from sonnia.sonia import GENE_FEATURE_OPTIONS
 from sonnia.sonia_paired import SoniaPaired
 
-
 class SoNNiaPaired(SoniaPaired):
     def __init__(
         self,
@@ -274,29 +273,8 @@ class SoNNiaPaired(SoniaPaired):
         self.vj_length_light = np.count_nonzero((initial == "v_l") | (initial == "j_l"))
         self.vj_length_heavy = np.count_nonzero((initial == "v_h") | (initial == "j_h"))
 
-        self.model = keras.models.load_model(
-            model_file,
-            custom_objects={
-                "loss": self._loss,
-                "likelihood": self._likelihood,
-                "EmbedViaMatrix": EmbedViaMatrix,
-                "clip": ko.clip,
-            },
-            compile=False,
-        )
-
-        if len(self.model.layers) == 3:
-            raise RuntimeError(
-                "The loaded model structure is supposed to be "
-                "for a SoniaPaired model, but a SoNNiaPaired "
-                "model is trying to be initialized. Try loading "
-                "the model using the SoniaPaired class instead."
-            )
-
-        self.optimizer = keras.optimizers.RMSprop()
-        self.model.compile(
-            optimizer=self.optimizer, loss=self._loss, metrics=[self._likelihood]
-        )
+        self.update_model_structure(initialize=True)
+        self.model.load_weights(model_file)
 
 
 class EmbedViaMatrix(keras.layers.Layer):

--- a/sonnia/sonnia_paired.py
+++ b/sonnia/sonnia_paired.py
@@ -5,8 +5,9 @@
 
 import logging
 from typing import *
-
-logging.getLogger("tensorflow").disabled = True
+import os
+#logging.getLogger("tensorflow").disabled = True
+os.environ["KERAS_BACKEND"] = "torch" # use torch backend
 
 import keras
 import keras.ops as ko

--- a/test.py
+++ b/test.py
@@ -30,7 +30,7 @@ PAIRED_CHAIN_MODELS = [
 ]
 
 class Test(unittest.TestCase):
-    
+
     def setUp(self):
         self.seqs = np.array(
             [['CASSAF', 'TRBV10-1', 'TRBJ2-7'],
@@ -39,9 +39,23 @@ class Test(unittest.TestCase):
              ['CRSSRF', 'TRBV10-1', 'TRBJ2-7']]
         )
 
+        self.seqs_paired = np.array([
+            ['CASSLLWRSEQYF', 'TRBV7-3', 'TRBJ2-7', 'CIVRVGAAGNKLTF','TRAV26-1', 'TRAJ17'],
+            ['CSARAYLSMNTEAFF', 'TRBV20-1', 'TRBJ1-1', 'CAPKLSF', 'TRAV12-3','TRAJ20'],
+            ['CAPPGSNQPQHF', 'TRBV6-4', 'TRBJ1-5', 'CATGGSNSNSGYALNF', 'TRAV17', 'TRAJ41'],
+            ['CASSKRPDQPQHF', 'TRBV9', 'TRBJ1-5', 'CAENKGQGNLIF', 'TRAV13-2', 'TRAJ42']])
+
     def test_save_load(self):
         for model in [Sonia, SoNNia]:
             qm = model(pgen_model='humanTRB',data_seqs=self.seqs)
+            qm.add_generated_seqs(10)
+            qm.save_model('test')
+            qm1 = model(ppost_model='test')
+            shutil.rmtree('test')
+            self.assertTrue(qm.feature_dict == qm1.feature_dict)
+
+        for model in [SoniaPaired, SoNNiaPaired]:
+            qm = model(pgen_model_light='human_T_alpha',pgen_model_heavy='human_T_beta',data_seqs=self.seqs_paired)
             qm.add_generated_seqs(10)
             qm.save_model('test')
             qm1 = model(ppost_model='test')
@@ -183,7 +197,7 @@ class Test(unittest.TestCase):
 if __name__ == "__main__":
     unittest.main()
 
-if __name__ == '__main__':
-    logging.basicConfig(stream=sys.stderr)
-    logging.getLogger('SoniaTests').setLevel(logging.DEBUG)
-    unittest.main()
+#if __name__ == '__main__':
+#    logging.basicConfig(stream=sys.stderr)
+#    logging.getLogger('SoniaTests').setLevel(logging.DEBUG)
+#    unittest.main()


### PR DESCRIPTION
This pull requests does 3 major changes:
- torch backend is enforced across the whole repo
- saving and loading of NN models is done only via weights (more constrained then before but should be more reliable and reproducible)
- added some residual connections in the model architecture to make it more stable

All tests run fine. We should think whether we could push to pip a new version (the current one is from august 2024 and a lot has changed since then)